### PR TITLE
Bug: Hero component causing side scroll

### DIFF
--- a/src/components/hero/index.tsx
+++ b/src/components/hero/index.tsx
@@ -63,7 +63,7 @@ export const Hero = ({
   }, []);
 
   return (
-    <div className="grid px-4 gap-2 grid-cols-1 h-[600px] lg:pl-10 lg:pr-10 lg:grid-cols-6 lg:gap-8 lg:items-center lg:justify-center my-4">
+    <div className="grid px-4 gap-2 grid-cols-1 h-[600px] lg:pl-10 lg:pr-10 lg:grid-cols-6 lg:gap-8 lg:items-center lg:justify-center my-4 overflow-hidden">
       {/* Left side */}
       <div className="grid grid-rows-6 md:grid-cols-6 lg:grid-cols-3 lg:grid-rows-3 gap-2 h-[600px] lg:col-span-3 lg:gap-8">
         {/* First section */}


### PR DESCRIPTION
**Bug**
- There was a bug present on screens lg and above where due to the starting position of the rideside div a side scroll would be possible.
<img width="1440" alt="Screenshot 2024-02-17 at 22 14 25" src="https://github.com/Chascript/Crossfit/assets/57460454/5931bb7b-1c34-4fd4-addb-c40ed4b8320e">

**Fix**
- I've added the css class overflow-hidden. This fixes the bug.