### PR TITLE
Component: Workout Of The Day

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,13 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+
+ul {
+  list-style-type: disc;
+  margin-left: 1.5em;
+}
+
+ul li {
+  margin-bottom: 0.5em; 
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,7 +21,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={inter.className}>
+      <body className={`${inter.className} overflow-x-hidden`}>
         <Providers>
           <Header />
           <main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -100,6 +100,7 @@ const HomePage = () => (
       linkText="Find Exercises"
       linkUrl="/exercises"
     />
+    <Divider className="w-5/6 m-auto" />
     <MultiplePoints
       heading="Core Principles"
       description="CrossFit's core principles ensure adaptable, comprehensive fitness for all levels, promoting lasting health and growth"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import fistBump from '../../public/images/fist-bump.jpg';
 import MultiplePoints from '../components/multiple-points';
 import { AccorItem, Bullets } from '../types';
 import CrossfitAccordion from '../components/crossfit-accordion';
+import WorkoutOfTheDayView from '../containers/workoutOfTheDayView';
 
 const CorePrinciples: Bullets[] = [
   {
@@ -105,6 +106,8 @@ const HomePage = () => (
       image={fistBump.src}
       bullets={CorePrinciples}
     />
+    <Divider className="w-5/6 m-auto" />
+    <WorkoutOfTheDayView />
     <Divider className="w-5/6 m-auto" />
     <CrossfitAccordion
       title="Crossfit FAQs"

--- a/src/components/hero/index.tsx
+++ b/src/components/hero/index.tsx
@@ -63,7 +63,7 @@ export const Hero = ({
   }, []);
 
   return (
-    <div className="grid px-4 gap-2 grid-cols-1 h-[600px] lg:pl-10 lg:pr-10 lg:grid-cols-6 lg:gap-8 lg:items-center lg:justify-center my-4 overflow-hidden">
+    <div className="grid px-4 gap-2 grid-cols-1 h-[600px] lg:pl-10 lg:pr-10 lg:grid-cols-6 lg:gap-8 lg:items-center lg:justify-center my-4">
       {/* Left side */}
       <div className="grid grid-rows-6 md:grid-cols-6 lg:grid-cols-3 lg:grid-rows-3 gap-2 h-[600px] lg:col-span-3 lg:gap-8">
         {/* First section */}

--- a/src/components/hero/index.tsx
+++ b/src/components/hero/index.tsx
@@ -63,7 +63,7 @@ export const Hero = ({
   }, []);
 
   return (
-    <div className="grid px-4 gap-2 grid-cols-1 h-[600px] lg:pl-10 lg:pr-10 lg:grid-cols-6 lg:gap-8 lg:items-center lg:justify-center my-4">
+    <div className="grid px-4 gap-2 grid-cols-1 h-[600px] lg:pl-10 lg:pr-10 lg:grid-cols-6 lg:gap-8 lg:items-center lg:justify-center mt-4 mb-12">
       {/* Left side */}
       <div className="grid grid-rows-6 md:grid-cols-6 lg:grid-cols-3 lg:grid-rows-3 gap-2 h-[600px] lg:col-span-3 lg:gap-8">
         {/* First section */}

--- a/src/components/multiple-points/index.tsx
+++ b/src/components/multiple-points/index.tsx
@@ -77,7 +77,7 @@ export const MultiplePoints = ({
         <Image
           src={image}
           alt="CrossFit ropes"
-          className="lg:h-auto w-40 rounded-full overflow-hidden bg-gray-200 border-4 border-gray-200 border-solid shadow-2xl"
+          className="lg:h-auto w-40 rounded-full bg-gray-200 border-4 border-gray-200 border-solid shadow-2xl"
           layout="fill"
           objectFit="cover"
         />

--- a/src/components/workout-of-the-day/index.tsx
+++ b/src/components/workout-of-the-day/index.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import {
+  Button, ButtonGroup, Card, CardBody, CardFooter, CardHeader, Divider,
+} from '@nextui-org/react';
+
+export interface Props {
+  isScaled: boolean;
+  setIsScaled: (isScaled: boolean) => void;
+}
+
+export const WorkoutOfTheDayCard = ({
+  isScaled,
+  setIsScaled,
+}:Props) => {
+  const scaledWorkout = (
+    <ul>
+      <li>Thrusters (lighter weights)</li>
+      <li>Knee Push-ups</li>
+      <li>60 Single-unders</li>
+      <li>Knee Raises</li>
+      <li>Step Ups</li>
+    </ul>
+  );
+
+  const rxWorkout = (
+    <ul>
+      <li>Thrusters (95/65 lbs)</li>
+      <li>Handstand Push-ups</li>
+      <li>30 Double-unders</li>
+      <li>Toes-to-bar</li>
+      <li>Box Jumps</li>
+    </ul>
+  );
+
+  return (
+    <Card className="max-w-[400px] w-full bg-gray-100 shadow-lg rounded-lg">
+      <CardHeader className="bg-gray-700 text-white py-4 px-6 rounded-t-lg font-medium">
+        <h3>
+          Workout Of The Day
+          {isScaled ? ' (Scaled)' : ' (Rx)'}
+        </h3>
+      </CardHeader>
+      <Divider className="border-gray-700" />
+      <CardBody className="flex flex-col text-gray-200 bg-gray-800 p-6">
+        {' '}
+        {/* Adjusted text color to text-gray-200 */}
+        {isScaled ? scaledWorkout : rxWorkout}
+        <p className="text-gray-300">Time: 10 minutes</p>
+        {' '}
+        {/* Adjusted text color to text-gray-300 for the time */}
+      </CardBody>
+      <Divider className="border-gray-700" />
+      <CardFooter className="flex justify-center bg-gray-700 py-4 rounded-b-lg">
+        <ButtonGroup className="flex flex-wrap">
+          <Button onClick={() => setIsScaled(true)} disabled={isScaled} className="bg-gray-800 text-white hover:bg-gray-600 disabled:bg-gray-600 disabled:text-gray-400 disabled:hover:bg-gray-600 disabled:hover:text-gray-400">
+            Scaled
+          </Button>
+          <Button onClick={() => setIsScaled(false)} disabled={!isScaled} className="bg-gray-800 text-white hover:bg-gray-600 disabled:bg-gray-600 disabled:text-gray-400 disabled:hover:bg-gray-600 disabled:hover:text-gray-400">
+            Rx
+          </Button>
+        </ButtonGroup>
+      </CardFooter>
+    </Card>
+
+  );
+};
+
+export default WorkoutOfTheDayCard;

--- a/src/components/workout-of-the-day/index.tsx
+++ b/src/components/workout-of-the-day/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {
   Button, ButtonGroup, Card, CardBody, CardFooter, CardHeader, Divider,
 } from '@nextui-org/react';
@@ -14,23 +15,21 @@ export const WorkoutOfTheDayCard = ({
 }:Props) => {
   const scaledWorkout = (
     <ul>
-      <li>Thrusters (lighter weights)</li>
-      <li>Knee Push-ups</li>
-      <li>60 Single-unders</li>
-      <li>Knee Raises</li>
-      <li>Step Ups</li>
+      <li>15 Thrusters (lighter weights)</li>
+      <li>40 Single-unders</li>
+      <li>10 Knee Raises</li>
     </ul>
   );
 
   const rxWorkout = (
     <ul>
-      <li>Thrusters (95/65 lbs)</li>
-      <li>Handstand Push-ups</li>
-      <li>30 Double-unders</li>
-      <li>Toes-to-bar</li>
-      <li>Box Jumps</li>
+      <li>15 Thrusters (95/65 lbs)</li>
+      <li>20 Double-unders</li>
+      <li>10 Toes-to-bar</li>
     </ul>
   );
+
+  const workoutFormat = 'AMRAP in 13 minutes';
 
   return (
     <Card className="max-w-[400px] w-full bg-gray-100 shadow-lg rounded-lg">
@@ -43,11 +42,9 @@ export const WorkoutOfTheDayCard = ({
       <Divider className="border-gray-700" />
       <CardBody className="flex flex-col text-gray-200 bg-gray-800 p-6">
         {' '}
-        {/* Adjusted text color to text-gray-200 */}
         {isScaled ? scaledWorkout : rxWorkout}
-        <p className="text-gray-300">Time: 10 minutes</p>
+        <p className="text-gray-300">{workoutFormat}</p>
         {' '}
-        {/* Adjusted text color to text-gray-300 for the time */}
       </CardBody>
       <Divider className="border-gray-700" />
       <CardFooter className="flex justify-center bg-gray-700 py-4 rounded-b-lg">

--- a/src/components/workout-of-the-day/workout-of-the-day.stories.tsx
+++ b/src/components/workout-of-the-day/workout-of-the-day.stories.tsx
@@ -1,0 +1,26 @@
+import { StoryObj, Meta } from '@storybook/react';
+import { WorkoutOfTheDayCard } from '.';
+
+const meta: Meta<typeof WorkoutOfTheDayCard> = {
+  component: WorkoutOfTheDayCard,
+  title: 'Components/WorkoutOfTheDayCard',
+  args: {
+    isScaled: true,
+    setIsScaled: () => {},
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof WorkoutOfTheDayCard>;
+
+export const ScaledWorkout: Story = {
+  args: {
+  },
+};
+
+export const Rx: Story = {
+  args: {
+    isScaled: false,
+  },
+};

--- a/src/containers/workoutOfTheDayView/index.tsx
+++ b/src/containers/workoutOfTheDayView/index.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+
+import WorkoutOfTheDayCard from '../../components/workout-of-the-day';
+
+export const WorkoutOfTheDayView = () => {
+  const [isScaled, setIsScaled] = useState(true);
+  const [isVisible, setIsVisible] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const options = {
+      root: null,
+      rootMargin: '0px',
+      threshold: 0.2,
+    };
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          observer.unobserve(entry.target);
+        }
+      });
+    }, options);
+
+    if (containerRef.current) {
+      observer.observe(containerRef.current);
+    }
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  const handleSetIsScaled = () => {
+    setIsScaled(!isScaled);
+  };
+
+  return (
+    <div ref={containerRef} className={`my-12 mx-10  transition-transform duration-2000 ${isVisible ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-52'}`}>
+      <h1 className="text-3xl font-medium mb-4">Workout Of The Day (WOD)</h1>
+      <div className="flex flex-col items-center justify-between lg:items-center lg:flex-row-reverse">
+        <div className="lg:flex-1 py-4 lg:pl-8">
+          <ul className="list-decimal leading-relaxed lg:text-large">
+            <li>
+              CrossFits WOD is a daily workout that combines varied movements
+              at high intensity.
+            </li>
+            <li>
+              It typically includes exercises from weightlifting, gymnastics, cardio, and bodyweight training.
+            </li>
+            <li>
+              WODs are designed to be scalable for different fitness levels, focus on intensity, and promote a sense of community.
+            </li>
+            <li>
+              They vary each day to prevent plateaus and keep workouts challenging and effective.
+            </li>
+            <li>
+              The WOD is a staple of CrossFit training and is a great way to improve your fitness and overall health.
+            </li>
+          </ul>
+        </div>
+        <WorkoutOfTheDayCard isScaled={isScaled} setIsScaled={handleSetIsScaled} />
+      </div>
+
+    </div>
+  );
+};
+
+export default WorkoutOfTheDayView;

--- a/src/containers/workoutOfTheDayView/workoutOfTheDayView.stories.tsx
+++ b/src/containers/workoutOfTheDayView/workoutOfTheDayView.stories.tsx
@@ -1,0 +1,14 @@
+import { StoryObj, Meta } from '@storybook/react';
+import WorkoutOfTheDayView from '.';
+
+export default {
+  title: 'Views/WorkoutOfTheDayView',
+  component: WorkoutOfTheDayView,
+  args: {},
+} as Meta;
+
+type Story = StoryObj<typeof WorkoutOfTheDayView>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,6 +6,7 @@ const config: Config = {
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/containers/**/*.{js,ts,jsx,tsx,mdx}',
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
     './node_modules/@nextui-org/theme/dist/**/*.{js,ts,jsx,tsx}',
   ],


### PR DESCRIPTION
# Whats been done...
- New component `WorkoutOfTheDay`. This component requires two props
 - `isScaled - boolean`, to show the scaled or rx workout
 - `buttonHandler function` to change the `isScaled boolean`
- New Container `WorkoutOfTheDayView` to handle state/functions. Text is also added here for this section.
- Stories built for both.

## Future updates for this component
- This component will use AI to generate a WOD each day at 00:00. 
- The component will then generate the html or values for the workout and render this
- Currently the workout is hardcoded, this was MVP to get the component built. The next step is to use AI to generate an RX and Scaled WOD.
- Ideally we want this component to open in a modal from the navigation so it is accessible on every page.
- Also, once we have more exercises listed on the app and have the individual pages setup this component will be able to link the user to that exercise page, for example the workout is....
```
  const rxWorkout = (
    <ul>
      <li>15 Thrusters (95/65 lbs)</li>
      <li>20 Double-unders</li>
      <li>10 Toes-to-bar</li>
    </ul>
  );
```
If the user doesn't know what a Double-under is, the text will be a link and will direct the user to `/exercises/double-unders`. On this page will contain videos, images, descriptions, everything about double-unders.

The WOD will also be available on the nav bar. So the user has direct access to the WOD. They can open it back up and click Toes-to-bar if they are not sure what this is or the correct form. It will take the user to `/exercises/toes-to-bar`, where all the needed info will be. 


### Other Miscellaneous updates
- Tailwind config update to include containers
- `overflow-x-hidden` added to the layout, so now no need to add to all components
- `Divider` added between home `Hero` and home `MultipleBullets` to keep page consistent
- Home `Hero` bottom margin added to keep page consisted.
- list style css added to `globals.css` to override `tailwindBase`

 ### Images

<img width="1359" alt="Screenshot 2024-02-24 at 14 29 10" src="https://github.com/Chascript/Crossfit/assets/57460454/8986d1d2-da72-416e-8c21-17c4630ad0b8">
<img width="958" alt="Screenshot 2024-02-24 at 14 31 24" src="https://github.com/Chascript/Crossfit/assets/57460454/4c1cc94c-c88a-4c04-9194-88979b9a73fc">
<img width="698" alt="Screenshot 2024-02-24 at 14 31 37" src="https://github.com/Chascript/Crossfit/assets/57460454/c75d755a-1309-4f01-a442-08ddbf2d9a8c">
<img width="510" alt="Screenshot 2024-02-24 at 14 32 58" src="https://github.com/Chascript/Crossfit/assets/57460454/a065f251-73d1-4f94-bd45-619b4fd70869">

