### PR TITLE
Components:  Movement and Muscle Groups

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,3 +11,7 @@ ul {
 ul li {
   margin-bottom: 0.5em; 
 }
+
+body,html {
+  overflow-x: hidden;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,3 +15,7 @@ ul li {
 body,html {
   overflow-x: hidden;
 }
+
+.h-inherit {
+  height: inherit;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,7 +21,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${inter.className} overflow-x-hidden`}>
+      <body className={`${inter.className}`}>
         <Providers>
           <Header />
           <main>

--- a/src/components/exercise/movement/index.tsx
+++ b/src/components/exercise/movement/index.tsx
@@ -6,7 +6,9 @@ interface Props {
   movement: Movement;
 }
 
-export const ExerciseMovement: React.FC<Props> = ({ movement }) => (
+export const ExerciseMovement = ({
+  movement,
+}: Props) => (
   <Card className="flex flex-1 p-3 shadow-md border border-black-400">
     <CardHeader>
       <h2 className="text-2xl font-semibold pb-0">Movement</h2>

--- a/src/components/exercise/movement/index.tsx
+++ b/src/components/exercise/movement/index.tsx
@@ -1,35 +1,50 @@
 import React from 'react';
 import { Movement } from '@/src/types';
+import { Card, CardBody, CardHeader } from '@nextui-org/react';
 
 interface Props {
   movement: Movement;
 }
 
 export const ExerciseMovement: React.FC<Props> = ({ movement }) => (
-  <div>
-    <h2>Movement</h2>
-    <p>
-      <strong>Description:</strong>
-      {' '}
-      {movement.description}
-    </p>
-    <p>
-      <strong>Purpose:</strong>
-      {' '}
-      {movement.purpose}
-    </p>
-    <p><strong>Benefits:</strong></p>
-    <ul>
-      {movement.benefits.map((benefit) => (
-        <li key={benefit}>{benefit}</li>
-      ))}
-    </ul>
-    <p>
-      <strong>Common Usage:</strong>
-      {' '}
-      {movement.commonUsage}
-    </p>
-  </div>
+  <Card className="flex flex-1 p-3 shadow-md border border-black-400">
+    <CardHeader>
+      <h2 className="text-2xl font-semibold pb-0">Movement</h2>
+    </CardHeader>
+    <CardBody className="space-y-1">
+      <p>
+        {movement.description}
+      </p>
+      <div>
+        <h3 className="text-lg font-medium">
+          Purpose
+        </h3>
+        {' '}
+        <p>
+          {movement.purpose}
+        </p>
+      </div>
+      <div>
+        <h3 className="text-lg font-medium">
+          Benefits
+        </h3>
+        <ul className="list-disc pl-5">
+          {movement.benefits.map((benefit) => (
+            <li key={benefit}>{benefit}</li>
+          ))}
+        </ul>
+      </div>
+      <div>
+        <h3 className="text-lg font-medium">
+          Common Usage
+        </h3>
+        {' '}
+        <p>
+          {movement.commonUsage}
+        </p>
+      </div>
+    </CardBody>
+  </Card>
 );
 
 export default ExerciseMovement;

--- a/src/components/exercise/movement/movement.stories.tsx
+++ b/src/components/exercise/movement/movement.stories.tsx
@@ -1,0 +1,14 @@
+import { StoryObj, Meta } from '@storybook/react';
+import ExerciseView from '.';
+
+export default {
+  title: 'Views/ExerciseView',
+  component: ExerciseView,
+  args: {},
+} as Meta;
+
+type Story = StoryObj<typeof ExerciseView>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/src/components/exercise/movement/movement.stories.tsx
+++ b/src/components/exercise/movement/movement.stories.tsx
@@ -1,14 +1,28 @@
 import { StoryObj, Meta } from '@storybook/react';
-import ExerciseView from '.';
+import ExerciseMovement from '.';
 
 export default {
-  title: 'Views/ExerciseView',
-  component: ExerciseView,
-  args: {},
+  title: 'Components/Exercise/ExerciseMovement',
+  component: ExerciseMovement,
+  args: {
+    movement: {
+      description: 'This is a description',
+      purpose: 'This is the purpose',
+      benefits: ['benefit 1', 'benefit 2', 'benefit 3'],
+      commonUsage: 'This is the common usage',
+    },
+  },
 } as Meta;
 
-type Story = StoryObj<typeof ExerciseView>;
+type Story = StoryObj<typeof ExerciseMovement>;
 
-export const Default: Story = {
-  args: {},
+export const Thrusters: Story = {
+  args: {
+    movement: {
+      description: 'Thrusters combine a front squat with an overhead press in one fluid movement. This exercise is highly functional, as it mimics real-world movements like lifting objects from the ground and pressing them overhead. It improves strength, power, and coordination.',
+      purpose: 'The purpose of thrusters is to build full-body strength, improve cardiovascular conditioning, and enhance functional movement patterns.',
+      benefits: ['Builds strength in legs, shoulders, and core', 'Improves power and explosiveness', 'Enhances cardiovascular endurance'],
+      commonUsage: 'Thrusters are commonly used in CrossFit workouts, often as part of high-intensity interval training (HIIT) or as a standalone strength exercise.',
+    },
+  },
 };

--- a/src/components/exercise/muscle-groups-worked/index.tsx
+++ b/src/components/exercise/muscle-groups-worked/index.tsx
@@ -1,30 +1,43 @@
 import React from 'react';
 import { MuscleGroupsWorked } from '@/src/types';
+import {
+  Card, CardBody, CardHeader, Divider,
+} from '@nextui-org/react';
 
 interface Props {
   muscleGroupsWorked: MuscleGroupsWorked;
 }
 
 export const ExerciseMuscleGroupsWorked: React.FC<Props> = ({ muscleGroupsWorked }) => (
-  <div>
-    <h2>Muscle Groups Worked</h2>
-    <p>
-      <strong>Primary Muscle Groups:</strong>
-      {' '}
-      {muscleGroupsWorked.primaryMuscleGroups.join(', ')}
-    </p>
-    <p>
-      <strong>Secondary Muscle Groups:</strong>
-      {' '}
-      {muscleGroupsWorked.secondaryMuscleGroups.join(', ')}
-    </p>
-    <p>
-      <strong>Description:</strong>
-      {' '}
-      {muscleGroupsWorked.description}
-    </p>
-    {/* Optionally, you can include a visual representation here */}
-  </div>
+  <Card className="flex flex-1 p-3 rounded-lg shadow-md border border-black-400">
+    <CardHeader>
+      <h2 className="text-2xl font-semibold">Muscle Groups Worked</h2>
+    </CardHeader>
+    <CardBody className="space-y-2">
+      <div className="flex flex-col sm:flex-row justify-evenly">
+        <div className="flex flex-col justify-start">
+          <h3 className="text-lg font-medium">Primary Muscle Groups</h3>
+          <ul className="list-disc">
+            {muscleGroupsWorked.primaryMuscleGroups.map((group) => (
+              <li key={group}>{group}</li>
+            ))}
+          </ul>
+        </div>
+        <Divider className="h-4/5" orientation="vertical" />
+        <div className="flex flex-col">
+          <h3 className="text-lg font-medium">Secondary Muscle Groups</h3>
+          <ul className="list-disc">
+            {muscleGroupsWorked.secondaryMuscleGroups.map((group) => (
+              <li key={group}>{group}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+      <p className="lg:w-5/6">
+        {muscleGroupsWorked.description}
+      </p>
+    </CardBody>
+  </Card>
 );
 
 export default ExerciseMuscleGroupsWorked;

--- a/src/components/exercise/muscle-groups-worked/index.tsx
+++ b/src/components/exercise/muscle-groups-worked/index.tsx
@@ -23,7 +23,7 @@ export const ExerciseMuscleGroupsWorked: React.FC<Props> = ({ muscleGroupsWorked
             ))}
           </ul>
         </div>
-        <Divider className="h-4/5" orientation="vertical" />
+        <Divider className="h-inherit" orientation="vertical" />
         <div className="flex flex-col">
           <h3 className="text-lg font-medium">Secondary Muscle Groups</h3>
           <ul className="list-disc">

--- a/src/components/exercise/muscle-groups-worked/index.tsx
+++ b/src/components/exercise/muscle-groups-worked/index.tsx
@@ -8,7 +8,9 @@ interface Props {
   muscleGroupsWorked: MuscleGroupsWorked;
 }
 
-export const ExerciseMuscleGroupsWorked: React.FC<Props> = ({ muscleGroupsWorked }) => (
+export const ExerciseMuscleGroupsWorked = ({
+  muscleGroupsWorked,
+}: Props) => (
   <Card className="flex flex-1 p-3 rounded-lg shadow-md border border-black-400">
     <CardHeader>
       <h2 className="text-2xl font-semibold">Muscle Groups Worked</h2>

--- a/src/components/exercise/muscle-groups-worked/muscle-groups-worked.stories.tsx
+++ b/src/components/exercise/muscle-groups-worked/muscle-groups-worked.stories.tsx
@@ -1,0 +1,26 @@
+import { StoryObj, Meta } from '@storybook/react';
+import ExerciseMuscleGroupsWorked from '.';
+
+export default {
+  title: 'Components/Exercise/ExerciseMuscleGroupsWorked',
+  component: ExerciseMuscleGroupsWorked,
+  args: {
+    muscleGroupsWorked: {
+      primaryMuscleGroups: ['Muscle1', 'Muscle2', 'Muscle3'],
+      secondaryMuscleGroups: ['Muscle4', 'Muscle5', 'Muscle6'],
+      description: 'This is a description',
+    },
+  },
+} as Meta;
+
+type Story = StoryObj<typeof ExerciseMuscleGroupsWorked>;
+
+export const Thrusters: Story = {
+  args: {
+    muscleGroupsWorked: {
+      primaryMuscleGroups: ['Quadriceps', 'Glutes', 'Shoulders'],
+      secondaryMuscleGroups: ['Hamstrings', 'Calves', 'Triceps'],
+      description: 'Thrusters are a compound exercise that targets multiple muscle groups. The primary muscles worked are the quadriceps, glutes, and shoulders. Secondary muscles worked include the hamstrings, calves, and triceps.',
+    },
+  },
+};

--- a/src/components/exercise/title/index.tsx
+++ b/src/components/exercise/title/index.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 
 import { Card, CardBody } from '@nextui-org/react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 import { DifficultyValue } from '@/src/types';
 import DifficultyRating from '../../difficulty-rating';
 
@@ -18,21 +16,20 @@ export const ExerciseTitle = ({
   difficulty,
 }: Props) => (
   <div className="flex justify-between">
-    <div className="flex flex-col">
-
-      <h1 className="text-5xl font-medium mb-4">{title}</h1>
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col sm:flex-col-reverse md:flex-row md:justify-between">
+        <h1 className="text-5xl font-medium mb-4">{title}</h1>
+        <div className="flex gap-4 justify-start content-end sm:justify-end">
+          Difficulty:
+          {' '}
+          <DifficultyRating value={difficulty} />
+        </div>
+      </div>
       <Card className="border border-black-400 rounded-lg p-2 flex">
         <CardBody className="flex flex-row gap-4">
-          <FontAwesomeIcon className="w-4" icon={faInfoCircle} />
           <p className="text-lg italic">{description}</p>
         </CardBody>
       </Card>
-    </div>
-
-    <div className="flex gap-4 justify-start content-end">
-      Difficulty:
-      {' '}
-      <DifficultyRating value={difficulty} />
     </div>
   </div>
 

--- a/src/components/exercise/title/index.tsx
+++ b/src/components/exercise/title/index.tsx
@@ -16,7 +16,7 @@ export const ExerciseTitle = ({
   difficulty,
 }: Props) => (
   <div className="flex justify-between">
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col flex-1 gap-4">
       <div className="flex flex-col sm:flex-col-reverse md:flex-row md:justify-between">
         <h1 className="text-5xl font-medium mb-4">{title}</h1>
         <div className="flex gap-4 justify-start content-end sm:justify-end">

--- a/src/components/exercise/title/title.stories.tsx
+++ b/src/components/exercise/title/title.stories.tsx
@@ -1,0 +1,22 @@
+import { StoryObj, Meta } from '@storybook/react';
+import ExerciseTitle from '.';
+
+export default {
+  title: 'Components/Exercise/ExerciseTitle',
+  component: ExerciseTitle,
+  args: {
+    title: 'Title',
+    description: 'This is a description',
+    difficulty: 1,
+  },
+} as Meta;
+
+type Story = StoryObj<typeof ExerciseTitle>;
+
+export const Thrusters: Story = {
+  args: {
+    title: 'Thrusters',
+    description: 'Thrusters combine a front squat with an overhead press in one fluid movement. This exercise is highly functional, as it mimics real-world movements like lifting objects from the ground and pressing them overhead. It improves strength, power, and coordination.',
+    difficulty: 3,
+  },
+};

--- a/src/containers/exerciseListView/index.tsx
+++ b/src/containers/exerciseListView/index.tsx
@@ -106,7 +106,7 @@ const ExerciseListView = ({
   };
 
   return (
-    <div className="container flex flex-col gap-4 p-4 mx-20">
+    <div className="container flex flex-col gap-4 p-4">
       <Input
         type="search"
         label="Search"

--- a/src/containers/exerciseView/index.tsx
+++ b/src/containers/exerciseView/index.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { fetchCrossfitExercise } from '@/src/server/crossfitExercises';
-import { Exercise } from '@/src/types';
-import NotFound from '@/src/app/exercises/not-found';
 
-import ExerciseTitle from '@/src/components/exercise/title';
-import { ExerciseMovement } from '@/src/components/exercise/movement';
+import { fetchCrossfitExercise } from '../../server/crossfitExercises';
+import { Exercise } from '../../types';
+import NotFound from '../../app/exercises/not-found';
+
+import ExerciseTitle from '../../components/exercise/title';
+import { ExerciseMovement } from '../../components/exercise/movement';
 import { ExerciseStepByStepGuide } from '../../components/exercise/step-by-step-guide';
 import { ExerciseMuscleGroupsWorked } from '../../components/exercise/muscle-groups-worked';
 import { CommonMistakes } from '../../components/exercise/common-mistakes';
@@ -12,7 +13,7 @@ import { ScalingOptions } from '../../components/exercise/scaling-options';
 import { SafetyTips } from '../../components/exercise/safety-tips';
 import { ExerciseSampleWorkout } from '../../components/exercise/sample-workout';
 
-interface Props {
+export interface Props {
   crossfitExercise: string;
 }
 

--- a/src/containers/exerciseView/index.tsx
+++ b/src/containers/exerciseView/index.tsx
@@ -24,15 +24,17 @@ export const ExerciseView = async ({ crossfitExercise }: Props) => {
   }
 
   return (
-    <div className="container mx-auto mt-8">
+    <div className="container flex flex-col gap-4 mx-2 sm:mx-auto mt-8">
       <ExerciseTitle
         title={exercise.title}
         description={exercise.description}
         difficulty={exercise.difficulty}
       />
-      <ExerciseMovement movement={exercise.movement} />
+      <div className="flex flex-col lg:flex-row gap-4">
+        <ExerciseMovement movement={exercise.movement} />
+        <ExerciseMuscleGroupsWorked muscleGroupsWorked={exercise.muscleGroupsWorked} />
+      </div>
       <ExerciseStepByStepGuide stepByStepGuide={exercise.stepByStepGuide} />
-      <ExerciseMuscleGroupsWorked muscleGroupsWorked={exercise.muscleGroupsWorked} />
       <CommonMistakes commonMistakes={exercise.commonMistakes} />
       <ScalingOptions scalingOptions={exercise.scalingOptions} />
       <SafetyTips safetyTips={exercise.safetyTips} />


### PR DESCRIPTION
#Whats been done...
- Component layout improved.
- both are responsive now
- Not fully complete, but better that just having plan text on the page.
- Stories created for both
- ExerciseTitle component layout improved for mobile, now responsive, removed the icon from the summeray text.
- Thrusters is shown as the example in the images below, but this is for every exercise page.

**Bug Fixes:**
- Whilst working I noticed side scroll on home page for mobile, CSS has been added to Globals rather than using tailwind, this has fixed this
- Margin removed on ExerciseList so responsive for mobile. Eventually margins will be added to layout, if needed.

Mobile:
<img width="342" alt="Screenshot 2024-03-02 at 16 37 37" src="https://github.com/Chascript/Crossfit/assets/57460454/342d47b6-085f-4356-b1e0-7770f6c283ee">
<img width="342" alt="Screenshot 2024-03-02 at 16 37 46" src="https://github.com/Chascript/Crossfit/assets/57460454/68451ebe-3e8a-4a61-b988-64724fb7dd77">

Desktop small width:
<img width="886" alt="Screenshot 2024-03-02 at 16 44 41" src="https://github.com/Chascript/Crossfit/assets/57460454/bb5b5b88-0ca6-4ace-82a9-022f7f7f1882">
<img width="886" alt="Screenshot 2024-03-02 at 16 44 46" src="https://github.com/Chascript/Crossfit/assets/57460454/4660f2ec-43c0-4bcb-aa28-d9bb1cce8b53">


Desktop (fullwidth):
<img width="1439" alt="Screenshot 2024-03-02 at 16 47 49" src="https://github.com/Chascript/Crossfit/assets/57460454/167a1176-6d73-4203-9f2b-9894e0f6415b">


