### PR TITLE
Bug: Search Exercises - fixed

### DIFF
--- a/src/containers/exerciseListView/index.tsx
+++ b/src/containers/exerciseListView/index.tsx
@@ -24,26 +24,25 @@ const ExerciseListView = ({
   const [filteredByQueryExercises, setFilteredByQueryExercises] = useState<Exercise[]>([]);
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [selectedDifficulty, setSelectedDifficulty] = useState<number[]>([]);
-  const [uniqueDifficulties, setUniqueDifficulties] = useState<number[]>([]);
-
-  const updateUniqueDifficulties = (allExercises: Exercise[]) => {
-    const uniqueDifficulty: number[] = [];
-    allExercises.forEach((exercise: Exercise) => {
-      if (!uniqueDifficulty.includes(exercise.difficulty)) {
-        uniqueDifficulty.push(exercise.difficulty);
-      }
-    });
-    uniqueDifficulty.sort((a: number, b: number) => a - b);
-    setUniqueDifficulties(uniqueDifficulty);
-  };
-
-  useEffect(() => {
-    updateUniqueDifficulties(filteredByQueryExercises);
-  }, [filteredByQueryExercises, searchQuery]);
+  const difficultyFilters = [{
+    value: 1,
+    label: '*',
+  }, {
+    value: 2,
+    label: '**',
+  }, {
+    value: 3,
+    label: '***',
+  }, {
+    value: 4,
+    label: '****',
+  }, {
+    value: 5,
+    label: '*****',
+  }];
 
   useEffect(() => {
     setExercises(crossfitExercises);
-    updateUniqueDifficulties(crossfitExercises);
   }, [crossfitExercises]);
 
   useEffect(() => {
@@ -125,14 +124,14 @@ const ExerciseListView = ({
         radius="full"
         placeholder="Select a Difficulty"
         selectionMode="multiple"
-        items={uniqueDifficulties.map((difficulty) => ({ value: difficulty, label: difficulty.toString() }))}
+        items={difficultyFilters.map((difficulty) => ({ value: difficulty.value, label: difficulty.label }))}
         onChange={handleDifficultyChange}
         className="max-w-xs"
       >
         {(difficulty) => <SelectItem key={difficulty.value} value={difficulty.value}>{difficulty.label}</SelectItem>}
       </Select>
       <div className="flex flex-wrap justify-start gap-4">
-        {filteredExercises.length === 0
+        {filteredExercises.length === 0 && searchQuery === '' && selectedDifficulty.length === 0
           ? (
             crossfitExercises.map((exercise) => (
               <ExerciseCard


### PR DESCRIPTION
# Bug:
- When selecting a difficulty first then typing in the search text box, the difficulty selected would change, or be removed.
- When searching for an exercise and there is no results, all the exercises would show

# Fix:
- Difficulty options are now const and not dynamic
- logic to render the filtered exercises has been changed, so if a search query or exercise has been selected it will always render the filtered list, not the full list. Full list will only render on load to ensure all exercises are in the page source code 

**Potential future issues avoid**
- The current logic would make it very difficult to add more filters, it would get complicated, fast!

**Notes:**
- My original idea was to have all the select options be dynamic and update based on what has been searched, I wanted to try and make it so a result was always present for the user, so to only show a difficulty where an exercise existed based on the searched query.
- A simpler, better , less confusing system is to just have all options present and selectable to the user, yes there will be times where no results are found, I will built an empty state component for this outcome when no exercises are present.